### PR TITLE
Fix setVisibility and getExpressId

### DIFF
--- a/src/IfcLoader.js
+++ b/src/IfcLoader.js
@@ -79,7 +79,7 @@ class IFCLoader extends Loader {
 
 		for (let index in this.mapFaceindexID) {
 
-		  if (parseInt(index) >= faceIndex) return this.mapFaceindexID[index];
+		  if (parseInt(index) > faceIndex) return this.mapFaceindexID[index];
 
 		}
 
@@ -120,7 +120,7 @@ class IFCLoader extends Loader {
 
 			if (expressIds.includes(this.mapFaceindexID[current])) {
 
-				for (var i = previous; i <= current; i++) this.setVertexVisibility(geometry, i, visible);
+				for (var i = previous; i < current; i++) this.setVertexVisibility(geometry, i, visible);
 
 			}
 


### PR DESCRIPTION
Hi,
I tried your IFCLoader and it seems that the setVisibility is messing some vector :

![Capture d’écran 2021-06-02 à 16 42 08](https://user-images.githubusercontent.com/3966864/120500974-8573df00-c3c1-11eb-8b1b-9e9ce5826d20.png)

The red sphere represent the position of the click.

As you can see, the object hidden is not the item clicked and the item clicked has some vertex hidden.

With the fix, here is the result :

![Capture d’écran 2021-06-02 à 16 44 06](https://user-images.githubusercontent.com/3966864/120501267-c5d35d00-c3c1-11eb-9a14-0bd819d1fd23.png)
